### PR TITLE
feat: Setup basic environment variables for settings Milestone 9.3

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -20,13 +21,13 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-&86lqn+bo@iw&qn-_uk!+n(!48%1l_g1)ecq@%f@3uu5ra4!33'
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dev-secret-key")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get("DJANGO_DEBUG", "True") == "True"
 
-ALLOWED_HOSTS = []
-
+hosts = os.environ.get("DJANGO_ALLOWED_HOSTS", "127.0.0.1,localhost")
+ALLOWED_HOSTS = [h.strip() for h in hosts.split(",") if h.strip()]
 
 # Application definition
 


### PR DESCRIPTION
Pull Request Title
Add environment variable support for SECRET_KEY, DEBUG, and ALLOWED_HOSTS (Milestone 9.3)

1. Summary of Changes
- Updated config/settings.py to load SECRET_KEY, DEBUG, and ALLOWED_HOSTS from environment variables.
- Added simple defaults (127.0.0.1, localhost) for local development.

2. Related Issues
Closes #12 

3. Implementation Details
- Replaced hardcoded settings with os.environ.get().
- SECRET_KEY now uses DJANGO_SECRET_KEY with a fallback.
- DEBUG reads from DJANGO_DEBUG.
- ALLOWED_HOSTS reads from DJANGO_ALLOWED_HOSTS, with a local-safe default.

4. Testing Summary
- Ran Django locally with default values → worked normally.
- Tested DEBUG=False with ALLOWED_HOSTS set → server responded correctly.

5. Deployment Notes
- On the VM, set:
DJANGO_SECRET_KEY, DJANGO_DEBUG=False, DJANGO_ALLOWED_HOSTS=<server-ip>.

6. Journal Update
Will update after merge.